### PR TITLE
Add temp fix for Safari 12+

### DIFF
--- a/src/local-browsers/safari.js
+++ b/src/local-browsers/safari.js
@@ -18,6 +18,7 @@
 
 const fs = require('fs');
 const webdriver = require('selenium-webdriver');
+const safari = require('selenium-webdriver/safari');
 
 const LocalBrowser = require('../browser-models/local-browser.js');
 const SafariConfig = require('../webdriver-config/safari.js');
@@ -54,11 +55,18 @@ class LocalSafariBrowser extends LocalBrowser {
     const seleniumOptions = this.getSeleniumOptions();
     seleniumOptions.setTechnologyPreview((this._release === 'beta'));
 
-    const builder = new webdriver
+    let builder = new webdriver
       .Builder()
       .withCapabilities(this._capabilities)
       .forBrowser(this.getId())
       .setSafariOptions(seleniumOptions);
+
+    // Run safari 12+ in legacy mode until this is resolved:
+    // https://github.com/SeleniumHQ/selenium/issues/6026
+    if (this.getVersionNumber() >= 12) {
+      builder = builder.usingServer(
+          new safari.ServiceBuilder().addArguments('--legacy').build().start());
+    }
 
     return builder;
   }


### PR DESCRIPTION
When Safari 12 was released, we stopped being able to run tests against it due to this issue:
https://github.com/SeleniumHQ/selenium/issues/6026

The PR conditionally puts Safari's webdriver into legacy mode when the version is 12 or greater.

Note: before adding this change, the Safari tests were failing, and after this change they pass for me. I'm not sure if any additional tests are needed beyond that.