### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ matrix:
     services:
       - xvfb
     node_js:
-      - node
+      - 12
   - name: "OS X (Latest Node)"
     os: osx
     node_js:
-      - node
+      - 12
     before_script:
       # See https://github.com/GoogleChromeLabs/selenium-assistant/issues/118
       - "sudo /usr/bin/safaridriver --enable"


### PR DESCRIPTION
# Changed log
- According to this [issue](https://github.com/grpc/grpc-node/issues/888#issuecomment-516918993), it seems that the latest node `13` version will be failed during compilation.

To fix the Travis CI build, using the `node 12` version instead.